### PR TITLE
Created SSH Key Rotate Ansible Role

### DIFF
--- a/roles/ssh_key_rotate/.travis.yml
+++ b/roles/ssh_key_rotate/.travis.yml
@@ -1,0 +1,29 @@
+---
+language: python
+python: "2.7"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/roles/ssh_key_rotate/README.md
+++ b/roles/ssh_key_rotate/README.md
@@ -1,0 +1,54 @@
+SSH_Key_Rotate
+=========
+
+SSH_key_Rotate is a role for changing ssh private keys on all servers specified in the running playbook.  The role 
+also publishes each device's public key to all other device's authorized_keys.  
+
+Requirements
+------------
+
+Currently, the inventory file will need to use hostnames instead of IP Addresses or DNS aliases.  This can be changed
+if needed by changing the "Fetch the keyfile from the remote device to the Ansible server" task (second to last)
+
+Role Variables
+--------------
+
+Defaut variables are maintained in: ssh_key_rotate/vars/main.yml 
+These variables can be overridden by passing them in your playbook as shown in the Example Playbook section below:
+
+username: user_to_change
+key_name: id_rsa  
+host_group: test_group         
+
+Note: "host_group" variable can be the same inventory group as hosts: defined in your playbook or it can be different.
+If "hosts:" and "host_group:" are the same, the net result is every device in your group will all over devices public 
+keys added to the authorized_keys file.  If "hosts:" and "host_group" are different, the net result is every device in
+"hosts" will have their public keys added to the authorized_keys file on each of the devices in "host_group".  
+
+Dependencies
+------------
+
+Requires gather_facts: yes
+
+Example Playbook
+----------------
+
+If you need to "restore" key based authentication with your servers you can use the ansible-playbook -k option to 
+pass your SSH Password in to your playbook.     
+ 
+      hosts: servers
+      gather_facts: yes
+      roles:
+         - { role: ssh_key_rotate, username: 'override_user', key_name: 'override_id_rsa', host_group: 'override_group' }
+
+
+License
+-------
+
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+Author Information
+------------------
+
+GitHub Repository: https://github.com/robertholl/Ansible_Roles

--- a/roles/ssh_key_rotate/defaults/main.yml
+++ b/roles/ssh_key_rotate/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for ssh_key_rotate

--- a/roles/ssh_key_rotate/handlers/main.yml
+++ b/roles/ssh_key_rotate/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for ssh_key_rotate

--- a/roles/ssh_key_rotate/meta/main.yml
+++ b/roles/ssh_key_rotate/meta/main.yml
@@ -1,0 +1,52 @@
+galaxy_info:
+  author: your name
+  description: your role description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.1
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/roles/ssh_key_rotate/tasks/main.yml
+++ b/roles/ssh_key_rotate/tasks/main.yml
@@ -1,0 +1,58 @@
+---
+# tasks file for ssh_key_rotate
+
+
+- name: "Delete SSH private Key for {{ username }}"
+  ansible.builtin.file:
+    path: "/home/{{ username }}/.ssh/{{ key_name }}"
+    state: absent
+
+- name: "Delete SSH public Key for {{ username }}"
+  ansible.builtin.file:
+    path: "/home/{{ username }}/.ssh/{{ key_name }}.pub"
+    state: absent
+
+- name: "SSH KeyGen command for {{ username }}"
+  tags: run
+  shell: "ssh-keygen -q -b 2048 -t rsa -N '' -C '{{ username }}@{{ ansible_hostname }}' -f /home/{{ username }}/.ssh/id_rsa"
+
+- name: Change ownership of private key
+  ansible.builtin.file:
+    path: "/home/{{ username }}/.ssh/{{ key_name }}"
+    state: file
+    owner: "{{ username }}"
+    group: "{{ username }}"
+
+- name: Change ownership of public key
+  ansible.builtin.file:
+    path: "/home/{{ username }}/.ssh/{{ key_name }}.pub"
+    state: file
+    owner: "{{ username }}"
+    group: "{{ username }}"
+
+- name: Create authorized_keys if file does not exist
+  ansible.builtin.file:
+    path: "/home/{{ username }}/.ssh/authorized_keys"
+    state: touch
+    owner: "{{ username }}"
+    group: "{{ username }}"
+
+- name: Fetch the keyfile from the remote device to the Ansible server
+  tags: run
+  fetch: 
+    src: "/home/{{ username }}/.ssh/id_rsa.pub"
+    dest: "buffer/{{ansible_hostname}}-id_rsa.pub"
+    flat: yes
+
+- name: Copy .pub key to authorized_keys using Ansible module
+  tags: runcd
+  authorized_key:
+    user: "{{ username }}"
+    state: present
+    key: "{{ lookup('file','buffer/{{item}}-id_rsa.pub')}}"
+  # Below line would avoid copying public key to authorized_keys on self. Issue if rotating the user used by Ansible and also managing Ansible Server.
+  # Currently all managed servers will get all other servers public keys added to authorized_keys as well as self.
+  #when: "{{ item != ansible_hostname }}"
+  with_items: 
+    - "{{ groups[vars['host_group']] }}"
+

--- a/roles/ssh_key_rotate/tests/inventory
+++ b/roles/ssh_key_rotate/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/roles/ssh_key_rotate/tests/test.yml
+++ b/roles/ssh_key_rotate/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - ssh_key_rotate

--- a/roles/ssh_key_rotate/vars/main.yml
+++ b/roles/ssh_key_rotate/vars/main.yml
@@ -1,0 +1,6 @@
+---
+# vars file for ssh_key_rotate
+
+username: user_to_change
+key_name: id_rsa  
+host_group: test_group


### PR DESCRIPTION
A new Ansible role for rotating ssh keys and deploying corresponding public keys to other devices in hosts group.